### PR TITLE
fix InputFilter Element

### DIFF
--- a/src/T4webBase/InputFilter/Element/Element.php
+++ b/src/T4webBase/InputFilter/Element/Element.php
@@ -23,15 +23,15 @@ class Element extends Input {
         }
     }
 
-    public function isValid($context = null) {
-        $result = parent::isValid($context);
+    // public function isValid($context = null) {
+    //     $result = parent::isValid($context);
 
-        if (!$result) {
-            $this->value = $this->defaultValue;
-        }
+    //     if (!$result) {
+    //         $this->value = $this->defaultValue;
+    //     }
         
-        return $result;
-    }
+    //     return $result;
+    // }
     
     public function isDefaultValue() {
         return $this->value === $this->defaultValue;


### PR DESCRIPTION
Когда не проходит isValid, он все значения элементов перезатирает на null. и когда в контроллере для вывода ошибок с введенными значениями вызывается getValues(), все невалидные значения будут пустыми. из-за этого и перезатирался урл, значение которому присваивалось в методе isValid, а сейчас и другие элементы перезатираются.
